### PR TITLE
Update OreGeneratorSettings trying to fix config file not loaded on DS issue

### DIFF
--- a/Data/Scripts/OreGenerator/OreGeneratorSession.cs
+++ b/Data/Scripts/OreGenerator/OreGeneratorSession.cs
@@ -23,7 +23,7 @@ namespace Stollie.OreGenerator
         public static List<IMyConveyorSorter> oreGenerators = new List<IMyConveyorSorter>();
         public static OreGeneratorSettings oreGeneratorSettings;
         public static float POWER_REQUIRED;
-        public static List<string> ORE_NAMES_AND_AMOUNTS;
+        public static Dictionary<string, int> ORE_NAMES_AND_AMOUNTS;
         public static int SECONDS_BETWEEN_CYCLES;
 
         internal string oreGeneratorSubtypeName = "SmallOreGenerator";
@@ -42,7 +42,8 @@ namespace Stollie.OreGenerator
             //if (!MyAPIGateway.Multiplayer.IsServer)
             //    return;
 
-            oreGeneratorSettings = OreGeneratorSettings.LoadConfigFile();
+            oreGeneratorSettings = new OreGeneratorSettings();
+            oreGeneratorSettings.LoadConfigFile();
             //var newOres = CheckConfigContent(oreGeneratorSettings.oreNamesAndAmounts);
             //if (newOres)
             //{
@@ -155,9 +156,8 @@ namespace Stollie.OreGenerator
             MyDefinitionManager.Static.GetOreTypeNames(out currentOreNames);
             foreach (var oreNameAndAmount in ORE_NAMES_AND_AMOUNTS)
             {
-                var splitString = oreNameAndAmount.Split(new[] { ',' }, 2);
-                int oreAmount = int.Parse(splitString[0]);
-                var oreName = splitString[1];
+                int oreAmount = oreNameAndAmount.Value;
+                var oreName = oreNameAndAmount.Key;
 
                 var item = new MyObjectBuilder_InventoryItem()
                 {


### PR DESCRIPTION
**Issues**
Some values in config (`OreGeneratorSettings`) is not loaded on DS. Current known is power value.

**Impact**
Conflict with #2

**Proposed Fix**
- Make `OreGeneratorSettings` pure instanced class to prevent possible leaks. Those leaks threw exception that halt file reading operation, which makes Settings fell back to default values.
- ~~Fix~~ Implement `Save()` method.
- Make Settings save back to config file right after loading it, succesfully or not. This is to make sure the config file is always in correct format (and contains enough values).
- Optimize Session Comp by changing the Ore-Amount list into a `Dictionary` so we don't have to split string and parse to `int` every few ticks. Now we only need to do that when loading config file.

**Additional Context**
This PR has a conflict with #2 in file `OreGeneratorSession.cs` @ Line 26.