### PR TITLE
Cleanup statics in Session and GameLogic

### DIFF
--- a/Data/Scripts/OreGenerator/OreGeneratorBlock.cs
+++ b/Data/Scripts/OreGenerator/OreGeneratorBlock.cs
@@ -35,8 +35,8 @@ namespace Stollie.OreGenerator
             {
                 Log.Info("*** Block Init Started ***");
                 block = (IMyCubeBlock)Entity;
-                powerRequired = OreGeneratorSession.POWER_REQUIRED;
-                Log.Info("Power Required Value Retrieved: " + OreGeneratorSession.POWER_REQUIRED);
+                powerRequired = OreGeneratorSession.Instance.POWER_REQUIRED;
+                Log.Info("Power Required Value Retrieved: " + OreGeneratorSession.Instance.POWER_REQUIRED);
                 powerSink = block.Components.Get<MyResourceSinkComponent>();
                 powerSink.ClearAllData();
                 if ((block as IMyFunctionalBlock).Enabled)
@@ -97,7 +97,7 @@ namespace Stollie.OreGenerator
         {
             Log.Info("*** Enable Change Started ***");
             powerSink.ClearAllData();
-            powerRequired = OreGeneratorSession.POWER_REQUIRED;
+            powerRequired = OreGeneratorSession.Instance.POWER_REQUIRED;
             if ((block as IMyFunctionalBlock).Enabled)
             {
                 //powerSink.SetInputFromDistributor(electricityId, powerRequired, false);

--- a/Data/Scripts/OreGenerator/OreGeneratorSession.cs
+++ b/Data/Scripts/OreGenerator/OreGeneratorSession.cs
@@ -18,13 +18,13 @@ namespace Stollie.OreGenerator
     {
         public static List<string> oreNamesAndAmounts = new List<string>();
 
-        public static HashSet<IMyEntity> entityList = new HashSet<IMyEntity>();
-        public static HashSet<IMyCubeGrid> gridsList = new HashSet<IMyCubeGrid>();
-        public static List<IMyConveyorSorter> oreGenerators = new List<IMyConveyorSorter>();
-        public static OreGeneratorSettings oreGeneratorSettings;
-        public static float POWER_REQUIRED;
-        public static List<string> ORE_NAMES_AND_AMOUNTS;
-        public static int SECONDS_BETWEEN_CYCLES;
+        public HashSet<IMyEntity> entityList = new HashSet<IMyEntity>();
+        public HashSet<IMyCubeGrid> gridsList = new HashSet<IMyCubeGrid>();
+        public List<IMyConveyorSorter> oreGenerators = new List<IMyConveyorSorter>();
+        public OreGeneratorSettings oreGeneratorSettings;
+        public float POWER_REQUIRED;
+        public List<string> ORE_NAMES_AND_AMOUNTS;
+        public int SECONDS_BETWEEN_CYCLES;
 
         internal string oreGeneratorSubtypeName = "SmallOreGenerator";
         internal static readonly MyDefinitionId electricityId = new MyDefinitionId(typeof(MyObjectBuilder_GasProperties), "Electricity");


### PR DESCRIPTION
**Issues**
Session Comp `OreGeneratorSession` too much `static`s, they may cause leaks.

**Impact**
Conflict with #1 

**Proposed Fix**
- Removing all `static`s in `OreGeneratorSession` class, except the static reference `OreGeneratorSession.Instance`.
- Make `OreGeneratorBlock` access those (previously static) values through a single static reference `OreGeneratorSession.Instance`.

**Additional Context**
This PR has a conflict with #1 in file `OreGeneratorSession.cs` @ Line 26.